### PR TITLE
chore: adopt new connector pkg for shared Task enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801033704-c6a602d6e5dc
+	github.com/instill-ai/connector v0.2.0-alpha.0.20230801091210-6dd88b698d85
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801085304-c9e30fb0f220
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
-github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4 h1:EQlkZ1QsMY3/W4bF6qL3SjII1qEKEa0n6XKRefCzIY8=
-github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4/go.mod h1:8L3fikA244oinWaSQk7/zyJ3xb81HgGezoWFxNDXBgk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801033704-c6a602d6e5dc h1:lpEvKuB6S1CwiL/cVirYcZAT28RuDPH8x7QIhUuE21o=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801033704-c6a602d6e5dc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.2.0-alpha.0.20230801091210-6dd88b698d85 h1:y2ZTrCT7Tit8vgiatq9bvW5LmFmELRwgKSmY9UeEr8M=
+github.com/instill-ai/connector v0.2.0-alpha.0.20230801091210-6dd88b698d85/go.mod h1:pWSwUcs6PwnWU+5LOxYVTTekksHTxlRKJ5jB8KS2t2A=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801085304-c9e30fb0f220 h1:moXVYUrVc8N4TFNVykVCiW5Ens2EzI09GhyuNV6F3u4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230801085304-c9e30fb0f220/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/airbyte/main.go
+++ b/pkg/airbyte/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/instill-ai/connector/pkg/base"
 	"github.com/instill-ai/connector/pkg/configLoader"
 
+	taskPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
@@ -522,6 +523,6 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	return connectorPB.Connector_STATE_ERROR, nil
 }
 
-func (con *Connection) GetTask() (connectorPB.Task, error) {
-	return connectorPB.Task_TASK_UNSPECIFIED, nil
+func (con *Connection) GetTask() (taskPB.Task, error) {
+	return taskPB.Task_TASK_UNSPECIFIED, nil
 }

--- a/pkg/instill/end/main.go
+++ b/pkg/instill/end/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/instill-ai/connector/pkg/base"
 	"github.com/instill-ai/connector/pkg/configLoader"
 
+	taskPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
@@ -72,6 +73,6 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	return connectorPB.Connector_STATE_CONNECTED, nil
 }
 
-func (con *Connection) GetTask() (connectorPB.Task, error) {
-	return connectorPB.Task_TASK_UNSPECIFIED, nil
+func (con *Connection) GetTask() (taskPB.Task, error) {
+	return taskPB.Task_TASK_UNSPECIFIED, nil
 }

--- a/pkg/instill/start/main.go
+++ b/pkg/instill/start/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/instill-ai/connector/pkg/base"
 	"github.com/instill-ai/connector/pkg/configLoader"
 
+	taskPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
@@ -69,6 +70,6 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	return connectorPB.Connector_STATE_CONNECTED, nil
 }
 
-func (con *Connection) GetTask() (connectorPB.Task, error) {
-	return connectorPB.Task_TASK_UNSPECIFIED, nil
+func (con *Connection) GetTask() (taskPB.Task, error) {
+	return taskPB.Task_TASK_UNSPECIFIED, nil
 }


### PR DESCRIPTION
Because

- we moved the Task enum to `common.task` protobuf

This commit

- adopt new connector pkg for shared Task enum
