### PR TITLE
chore: use `ConnectorResource_State` enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
+	github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b h1:JZVgUHWQUkSPbDCZHlDjWLtvw1aHmMHmcaOOLnCoqNo=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b/go.mod h1:cvOiC8gIcwbck/wYLqNSkY2BodUT9BiMBoJyXjjI+AE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea h1:xe1M6Gc50grThPZ8bfK5vx9N17vazvLj4HeD4lUefgo=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea/go.mod h1:bx5IhszAZ/bIJNsQbKqCTY+dr4rJPORhqfP1lwbbHnk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/airbyte/main.go
+++ b/pkg/airbyte/main.go
@@ -373,11 +373,11 @@ func (con *Connection) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, e
 	return outputs, nil
 }
 
-func (con *Connection) Test() (connectorPB.Connector_State, error) {
+func (con *Connection) Test() (connectorPB.ConnectorResource_State, error) {
 
 	def, err := con.connector.GetConnectorDefinitionByUid(con.DefUid)
 	if err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 	imageName := fmt.Sprintf("%s:%s",
 		def.VendorAttributes.GetFields()["dockerRepository"].GetStringValue(),
@@ -387,7 +387,7 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 
 	// Write config into a container local file
 	if err := os.MkdirAll(filepath.Dir(configFilePath), os.ModePerm); err != nil {
-		return connectorPB.Connector_STATE_ERROR, fmt.Errorf(fmt.Sprintf("unable to create folders for filepath %s", configFilePath), "WriteContainerLocalFileError", err)
+		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf(fmt.Sprintf("unable to create folders for filepath %s", configFilePath), "WriteContainerLocalFileError", err)
 	}
 
 	configuration := func() []byte {
@@ -402,7 +402,7 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	}()
 
 	if err := os.WriteFile(configFilePath, configuration, 0644); err != nil {
-		return connectorPB.Connector_STATE_ERROR, fmt.Errorf(fmt.Sprintf("unable to write connector config file %s", configFilePath), "WriteContainerLocalFileError", err)
+		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf(fmt.Sprintf("unable to write connector config file %s", configFilePath), "WriteContainerLocalFileError", err)
 	}
 
 	defer func() {
@@ -416,12 +416,12 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 
 	out, err := con.connector.dockerClient.ImagePull(context.Background(), imageName, types.ImagePullOptions{})
 	if err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 	defer out.Close()
 
 	if _, err := io.Copy(os.Stdout, out); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	resp, err := con.connector.dockerClient.ContainerCreate(context.Background(),
@@ -450,18 +450,18 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 		},
 		nil, nil, containerName)
 	if err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	if err := con.connector.dockerClient.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{}); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	statusCh, errCh := con.connector.dockerClient.ContainerWait(context.Background(), resp.ID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errCh:
 		if err != nil {
-			return connectorPB.Connector_STATE_ERROR, err
+			return connectorPB.ConnectorResource_STATE_ERROR, err
 		}
 	case <-statusCh:
 	}
@@ -472,7 +472,7 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 			ShowStdout: true,
 		},
 	); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	if err := con.connector.dockerClient.ContainerRemove(context.Background(), containerName,
@@ -480,12 +480,12 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 			RemoveVolumes: true,
 			Force:         true,
 		}); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	var bufStdOut, bufStdErr bytes.Buffer
 	if _, err := stdcopy.StdCopy(&bufStdOut, &bufStdErr, out); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	var teeStdOut io.Reader = strings.NewReader(bufStdOut.String())
@@ -495,10 +495,10 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 
 	var byteStdOut, byteStdErr []byte
 	if byteStdOut, err = io.ReadAll(teeStdOut); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 	if byteStdErr, err = io.ReadAll(teeStdErr); err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 
 	con.Logger.Info(fmt.Sprintf("ImageName, %s, ContainerName, %s, STDOUT, %v, STDERR, %v", imageName, containerName, byteStdOut, byteStdErr))
@@ -507,7 +507,7 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	for scanner.Scan() {
 
 		if err := scanner.Err(); err != nil {
-			return connectorPB.Connector_STATE_ERROR, err
+			return connectorPB.ConnectorResource_STATE_ERROR, err
 		}
 
 		var jsonMsg map[string]interface{}
@@ -516,14 +516,14 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 			case "CONNECTION_STATUS":
 				switch jsonMsg["connectionStatus"].(map[string]interface{})["status"] {
 				case "SUCCEEDED":
-					return connectorPB.Connector_STATE_CONNECTED, nil
+					return connectorPB.ConnectorResource_STATE_CONNECTED, nil
 				case "FAILED":
-					return connectorPB.Connector_STATE_ERROR, nil
+					return connectorPB.ConnectorResource_STATE_ERROR, nil
 				default:
-					return connectorPB.Connector_STATE_ERROR, fmt.Errorf("UNKNOWN STATUS")
+					return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("UNKNOWN STATUS")
 				}
 			}
 		}
 	}
-	return connectorPB.Connector_STATE_ERROR, nil
+	return connectorPB.ConnectorResource_STATE_ERROR, nil
 }


### PR DESCRIPTION
Because

- In proto, `Connector` has been renamed to `ConnectorResource`

This commit

- use `ConnectorResource_State` enum
