### PR TITLE
chore: fix json-schema bug

### DIFF
--- a/pkg/airbyte/config/definitions.json
+++ b/pkg/airbyte/config/definitions.json
@@ -1520,7 +1520,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "2.0.1",
+      "dockerImageTag": "2.0.4",
       "dockerRepository": "airbyte/destination-bigquery",
       "githubIssueLabel": "destination-bigquery",
       "license": "ELv2",
@@ -6972,6 +6972,16 @@
     "id": "airbyte-destination-langchain",
     "public": true,
     "releaseDate": "2023-07-15",
+    "releases": {
+      "breakingChanges": {
+        "0.1.0": {
+          "message": "This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.\n",
+          "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/langchain-migrations#0.1.0",
+          "upgradeDeadline": "2023-09-18"
+        }
+      },
+      "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/langchain-migrations"
+    },
     "spec": {
       "component_specification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -7279,7 +7289,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.8",
+      "dockerImageTag": "0.1.0",
       "dockerRepository": "airbyte/destination-langchain",
       "githubIssueLabel": "destination-langchain",
       "license": "MIT",
@@ -9895,7 +9905,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.2",
+      "dockerImageTag": "0.0.4",
       "dockerRepository": "airbyte/destination-pinecone",
       "githubIssueLabel": "destination-pinecone",
       "license": "MIT",
@@ -14530,7 +14540,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "3.0.0",
+      "dockerImageTag": "3.1.1",
       "dockerRepository": "airbyte/destination-snowflake",
       "githubIssueLabel": "destination-snowflake",
       "license": "ELv2",

--- a/pkg/airbyte/config/seed/definitions.json
+++ b/pkg/airbyte/config/seed/definitions.json
@@ -1140,7 +1140,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "2.0.1",
+      "dockerImageTag": "2.0.4",
       "dockerRepository": "airbyte/destination-bigquery",
       "githubIssueLabel": "destination-bigquery",
       "license": "ELv2",
@@ -4996,6 +4996,16 @@
     "id": "airbyte-destination-langchain",
     "public": true,
     "releaseDate": "2023-07-15",
+    "releases": {
+      "breakingChanges": {
+        "0.1.0": {
+          "message": "This version changes the way record ids are tracked internally. If you are using a stream in **append-dedup** mode, you need to reset the connection after doing the upgrade to avoid duplicates.\n",
+          "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/langchain-migrations#0.1.0",
+          "upgradeDeadline": "2023-09-18"
+        }
+      },
+      "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/langchain-migrations"
+    },
     "spec": {
       "component_specification": {
         "$ref": "component.json"
@@ -5227,7 +5237,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.8",
+      "dockerImageTag": "0.1.0",
       "dockerRepository": "airbyte/destination-langchain",
       "githubIssueLabel": "destination-langchain",
       "license": "MIT",
@@ -7159,7 +7169,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.2",
+      "dockerImageTag": "0.0.4",
       "dockerRepository": "airbyte/destination-pinecone",
       "githubIssueLabel": "destination-pinecone",
       "license": "MIT",
@@ -10654,7 +10664,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "3.0.0",
+      "dockerImageTag": "3.1.1",
       "dockerRepository": "airbyte/destination-snowflake",
       "githubIssueLabel": "destination-snowflake",
       "license": "ELv2",

--- a/pkg/pinecone/config/definitions.json
+++ b/pkg/pinecone/config/definitions.json
@@ -83,7 +83,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -102,7 +102,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -121,7 +121,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "boolean",
                           "default": false,
@@ -141,7 +141,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "boolean",
                           "default": false,
@@ -160,7 +160,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -174,7 +174,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",

--- a/pkg/pinecone/config/seed/generate_definitions.py
+++ b/pkg/pinecone/config/seed/generate_definitions.py
@@ -130,7 +130,7 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
         if title != "":
             field["title"] = title
@@ -138,9 +138,9 @@ def convert_field(field):
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType


### PR DESCRIPTION
Because

- we should use `anyOf` in json-schema rather than `oneOf`

This commit

- fix json-schema bug
