### PR TITLE
feat(gcs): add more output fields for upload task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.50.0
+	cloud.google.com/go/iam v0.13.0
 	cloud.google.com/go/storage v1.29.0
 	github.com/allegro/bigcache v1.2.1
 	github.com/docker/docker v24.0.2+incompatible
@@ -21,7 +22,6 @@ require (
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/compute v1.19.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	cloud.google.com/go/iam v0.13.0 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect

--- a/pkg/googlecloudstorage/config/tasks.json
+++ b/pkg/googlecloudstorage/config/tasks.json
@@ -30,9 +30,37 @@
     "output": {
       "type": "object",
       "properties": {
-        "status": {
+        "authenticated_url": {
+          "title": "Authenticated URL",
+          "description": "Only users granted permission can access the object with this link",
           "type": "string",
+          "format": "uri",
+          "instillFormat": "text"
+        },
+        "gsutil_uri": {
+          "title": "gsutil URI",
+          "description": "File path to this resource in Cloud Storage",
+          "type": "string",
+          "format": "uri",
+          "instillFormat": "text"
+        },
+        "public_url": {
+          "title": "Public URL",
+          "description": "Anyone with this link can access the object on the public Internet",
+          "type": "string",
+          "format": "uri",
+          "instillFormat": "text"
+        },
+        "public_access": {
+          "title": "Public access",
+          "description": "Whether the object is publicly accessible",
+          "type": "boolean",
+          "instillFormat": "boolean"
+        },
+        "status": {
+          "title": "Upload status",
           "description": "Status of the upload operation",
+          "type": "string",
           "instillFormat": "text"
         }
       }

--- a/pkg/googlecloudstorage/upload.go
+++ b/pkg/googlecloudstorage/upload.go
@@ -20,6 +20,7 @@ func uploadToGCS(client *storage.Client, bucketName, objectName, data string) er
 }
 
 // Check if an object in GCS is public or not
+// Refer to https://stackoverflow.com/questions/68722565/how-to-check-if-a-file-in-gcp-storage-is-public-or-not
 func isObjectPublic(client *storage.Client, bucketName, objectName string) (bool, error) {
 	ctx := context.Background()
 	bucket := client.Bucket(bucketName)

--- a/pkg/googlecloudstorage/upload.go
+++ b/pkg/googlecloudstorage/upload.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"io"
 
+	"cloud.google.com/go/iam"
 	"cloud.google.com/go/storage"
 )
 
+// Write an object to GCS bucket
 func uploadToGCS(client *storage.Client, bucketName, objectName, data string) error {
 	wc := client.Bucket(bucketName).Object(objectName).NewWriter(context.Background())
 	b, _ := base64.StdEncoding.DecodeString(data)
@@ -15,4 +17,45 @@ func uploadToGCS(client *storage.Client, bucketName, objectName, data string) er
 		return err
 	}
 	return wc.Close()
+}
+
+// Check if an object in GCS is public or not
+func isObjectPublic(client *storage.Client, bucketName, objectName string) (bool, error) {
+	ctx := context.Background()
+	bucket := client.Bucket(bucketName)
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	public := false
+	// When uniform bucket-level access is enabled on a bucket, Access Control Lists (ACLs) are disabled,
+	// and only bucket-level Identity and Access Management (IAM) permissions grant access to that bucket and the objects it contains.
+	// You revoke all access granted by object ACLs and the ability to administrate permissions using bucket ACLs.
+	if attrs.UniformBucketLevelAccess.Enabled {
+		policy, err := bucket.IAM().Policy(ctx)
+		if err != nil {
+			return false, err
+		}
+		for _, r := range policy.Roles() {
+			for _, m := range policy.Members(r) {
+				if m == iam.AllUsers {
+					public = true
+					break
+				}
+			}
+		}
+	} else {
+		objAttrs, err := bucket.Object(objectName).Attrs(ctx)
+		if err != nil {
+			return false, err
+		}
+		for _, v := range objAttrs.ACL {
+			if v.Entity == storage.AllUsers {
+				public = true
+				break
+			}
+		}
+	}
+	return public, nil
 }


### PR DESCRIPTION
Because

- we want to expose more information about the uploaded object for the "TASK_UPLOAD" task of the GCS connector

This commit

- add several output fields `authenticated_url`, `gsutil_uri`, `public_url` and `public_access`  when the upload operation is successful 
